### PR TITLE
Refactor command logic, add a http server that can receive and execute commands

### DIFF
--- a/src/AlphaBot2.py
+++ b/src/AlphaBot2.py
@@ -93,6 +93,11 @@ class AlphaBot2(object):
             GPIO.output(self.BIN2,GPIO.HIGH)
             self.PWMB.ChangeDutyCycle(0 - left)
 
+    # So code using this module can clean up without needing to import the GPIO module
+    @staticmethod
+    def gpio_cleanup():
+        GPIO.cleanup()
+
 if __name__=='__main__':
 
     Ab = AlphaBot2()

--- a/src/command_handler.py
+++ b/src/command_handler.py
@@ -1,0 +1,56 @@
+
+import time
+
+#
+# Base class for taking user input text and calling
+# a method based on what the command is.
+#
+class CommandHandler(object):
+    def __init__(self):
+        self.setup()
+
+    #
+    # Takes a user command, calls the applicable method (maybe) and
+    # returns an informational string that we expect the user to see.
+    # TODO: Use proper logging instead of returning strings
+    #
+    def do_command(self, user_input):
+        # Support passing extra params even though it's
+        # not used for anything yet
+        split_input = user_input.strip().lower().split()
+        command, args = split_input[0], split_input[1:]
+
+        # valid_commands returns a list of commands, each one like this:
+        # ["methodname", "shortcut1", "shortcut2", ..., "Description"]
+        for valid_command in self.valid_commands():
+            if command in valid_command[0:-1]:
+                self.call_method(valid_command[0], *args)
+                return "Performed '{}'".format(valid_command[-1])
+
+        return "Unknown command '{}'".format(command)
+
+    def call_method(self, method_name, *args):
+        # Assume a method with the right name is defined
+        getattr(self, method_name)(*args)
+        # In future this could configurable or done in a post-command
+        # hook, but for now we sleep for a second after all commands
+        time.sleep(1)
+
+    def help(self):
+        help_text = "Commands:\n"
+        for valid_command in self.valid_commands():
+            help_text += "  "
+            help_text += " ".join([c for c in valid_command[0:-1]])
+            help_text += " - " + valid_command[-1] + "\n"
+        return help_text.rstrip()
+
+    def valid_commands(self):
+        if hasattr(self.__class__, 'VALID_COMMANDS'):
+            return self.__class__.VALID_COMMANDS
+        return []
+
+    def setup(self):
+        pass
+
+    def cleanup(self):
+        pass

--- a/src/dummy_commands.py
+++ b/src/dummy_commands.py
@@ -1,0 +1,16 @@
+
+from command_handler import CommandHandler
+
+# Use the same name as the real hander and the same
+# command list so we can drop it in without other changes.
+class R2L2Commands(CommandHandler):
+    VALID_COMMANDS = [
+        ["forward", "f", "go", "Move forward"],
+        ["backward", "b", "Move backward"],
+        ["left", "l", "Move left"],
+        ["right", "r", "Move right"],
+    ]
+
+    # Override the base class method so we do nothing
+    def call_method(self, *args):
+        pass

--- a/src/move_cli.py
+++ b/src/move_cli.py
@@ -1,26 +1,26 @@
-from AlphaBot2 import AlphaBot2
-import time
 
-Ab = AlphaBot2()
+from r2l2_commands import R2L2Commands
+#from dummy_commands import R2L2Commands
+
+commands = R2L2Commands()
+prompt = ">> "
 
 try:
     while True:
-        Ab.stop()
-        user_input = raw_input("What should I do now?")
-        if user_input == "forward" or user_input.lower() == "f":
-            Ab.forward()
-        elif user_input == "backward" or user_input.lower() == "b" :
-            Ab.backward()
-        elif user_input == "left" or user_input.lower() == "l":
-            Ab.left()
-        elif user_input == "right" or user_input.lower() == "r":
-            Ab.right()
-        elif user_input == "x":
+        user_input = raw_input(prompt).strip().lower()
+        # help and exit are special commands that we handle here directly
+        if user_input in ['help', 'h', '?']:
+            print(commands.help())
+            print("  help h ? - Help")
+            print("  exit x q Ctrl-C - Exit")
+        elif user_input in ['exit', 'x', 'q']:
+            print("Bye")
             break
+        # Other commands are passed through to the command handler
         else:
-            print("That command isnt valid. Please try f=forward, b=backwards, l=left, r=right or x to exit.")
-        time.sleep(1)
+            print(commands.do_command(user_input))
+
 except KeyboardInterrupt:
-    print("\n")
+    print("\nBye")
 finally:
-    AlphaBot2.gpio_cleanup()
+    commands.cleanup()

--- a/src/move_cli.py
+++ b/src/move_cli.py
@@ -16,9 +16,11 @@ try:
         elif user_input == "right" or user_input.lower() == "r":
             Ab.right()
         elif user_input == "x":
-            raise KeyboardInterrupt
+            break
         else:
             print("That command isnt valid. Please try f=forward, b=backwards, l=left, r=right or x to exit.")
         time.sleep(1)
 except KeyboardInterrupt:
+    print("\n")
+finally:
     AlphaBot2.gpio_cleanup()

--- a/src/move_cli.py
+++ b/src/move_cli.py
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
 
 from r2l2_commands import R2L2Commands
 #from dummy_commands import R2L2Commands
 
 commands = R2L2Commands()
-prompt = ">> "
+
+#prompt = ">> "
+prompt = "🤖> "
 
 try:
     while True:

--- a/src/move_cli.py
+++ b/src/move_cli.py
@@ -1,4 +1,3 @@
-import RPi.GPIO as GPIO
 from AlphaBot2 import AlphaBot2
 import time
 
@@ -22,4 +21,4 @@ try:
             print("That command isnt valid. Please try f=forward, b=backwards, l=left, r=right or x to exit.")
         time.sleep(1)
 except KeyboardInterrupt:
-    GPIO.cleanup()
+    AlphaBot2.gpio_cleanup()

--- a/src/move_http.py
+++ b/src/move_http.py
@@ -1,0 +1,49 @@
+
+import cgi
+from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+
+from r2l2_commands import R2L2Commands
+#from dummy_commands import R2L2Commands
+
+commands = R2L2Commands()
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def input_form_html(self):
+        return(
+            '<h1>R2L2</h1>' +
+            '<pre>' + commands.help() + '</pre>' +
+            '<form method="post"><tt>' +
+            'Enter command: <input name="command">' +
+            '<input type="Submit"></tt></form>')
+
+    def send_html_content(self, *content):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write("\n".join(content))
+
+    def do_GET(self):
+        self.send_html_content(self.input_form_html())
+
+    def do_POST(self):
+        # we have to do this manually here ourselves..? wtf python
+        post_data = cgi.FieldStorage(fp=self.rfile, headers=self.headers,
+            environ={'REQUEST_METHOD':'POST', 'CONTENT_TYPE':self.headers['Content-Type']})
+
+        if 'command' in post_data:
+            user_input = post_data['command'].value
+            self.log_message("R2L2 user input: %s", user_input)
+
+            command_response = commands.do_command(user_input)
+            self.log_message("R2L2 response: %s", command_response)
+
+            self.send_html_content(self.input_form_html(), '<tt>' + command_response + '</tt>')
+
+        else:
+            self.send_html_content(self.input_form_html())
+
+try:
+    server = HTTPServer(('', 8080), RequestHandler)
+    server.serve_forever();
+finally:
+    commands.cleanup()

--- a/src/r2l2_commands.py
+++ b/src/r2l2_commands.py
@@ -1,0 +1,31 @@
+
+from AlphaBot2 import AlphaBot2
+from command_handler import CommandHandler
+
+class R2L2Commands(CommandHandler):
+    VALID_COMMANDS = [
+        ["forward", "f", "Move forward"],
+        ["backward", "b", "Move backward"],
+        ["left", "l", "Move left"],
+        ["right", "r", "Move right"],
+    ]
+
+    def setup(self):
+        self.bot = AlphaBot2()
+        self.bot.stop()
+
+    def cleanup(self):
+        self.bot.stop()
+        AlphaBot2.gpio_cleanup()
+
+    def forward(self):
+        self.bot.forward()
+
+    def backward(self):
+        self.bot.backward()
+
+    def left(self):
+        self.bot.left()
+
+    def right(self):
+        self.bot.right()


### PR DESCRIPTION
This adds a HTTP server that runs on port 8080. It runs in the foreground and start it similarly to move_cli.py:

    python move_http.py

The server provides a very basic form where you can send commands to R2L2.

I haven't tried it on the real system, so there could be some bugs, but I've tested it with a dummy command handler (code included) that can run without the robot.

There's some related refactoring so that the command logic is separated from the CLI code. And there's some minor tweaks about improving the way cleanup and existing is handled.

See the commits for more details.